### PR TITLE
Fixed PHP 7.4+ deprecated warning

### DIFF
--- a/src/EasyCSRF.php
+++ b/src/EasyCSRF.php
@@ -81,7 +81,7 @@ class EasyCSRF {
 		$max = strlen($seed) - 1;
 		$string = '';
 		for ($i = 0; $i < $length; ++$i) {
-			$string .= $seed{intval(mt_rand(0.0, $max))};
+			$string .= $seed[intval(mt_rand(0.0, $max))];
 		}
 
 		return $string;


### PR DESCRIPTION
Just fixed the deprecated warning in PHP 7.4+ for array and string offset access syntax.