### PR TITLE
Corrected return type in referralHash() to string instead of void.

### DIFF
--- a/src/EasyCSRF.php
+++ b/src/EasyCSRF.php
@@ -106,7 +106,7 @@ class EasyCSRF
     /**
      * Return a unique referral hash.
      *
-     * @return void
+     * @return string
      */
     protected function referralHash()
     {


### PR DESCRIPTION
Minor correction in the docblock return type for EasyCSRF.php's referrelHash().