### PR TITLE
fix undefined $_SERVER['HTTP_USER_AGENT']

### DIFF
--- a/src/EasyCSRF.php
+++ b/src/EasyCSRF.php
@@ -110,6 +110,10 @@ class EasyCSRF
      */
     protected function referralHash()
     {
+        if (empty($_SERVER['HTTP_USER_AGENT'])) {
+            return sha1($_SERVER['REMOTE_ADDR']);
+        }
+
         return sha1($_SERVER['REMOTE_ADDR'] . $_SERVER['HTTP_USER_AGENT']);
     }
 

--- a/tests/EasyCSRFTest.php
+++ b/tests/EasyCSRFTest.php
@@ -9,7 +9,7 @@ class EasyCSRFTest extends TestCase
 {
     protected $easyCSRF;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $_SERVER['REMOTE_ADDR'] = '1.1.1.1';
         $_SERVER['HTTP_USER_AGENT'] = 'useragent';
@@ -79,5 +79,14 @@ class EasyCSRFTest extends TestCase
         $token = $this->easyCSRF->generate('test');
         sleep(2);
         $this->easyCSRF->check('test', $token, 1);
+    }
+
+    public function testUndefinedUserAgent()
+    {
+        unset($_SERVER['HTTP_USER_AGENT']);
+
+        $token = $this->easyCSRF->generate('test');
+
+        $this->assertNotNull($token);
     }
 }


### PR DESCRIPTION
Hello,

First, thank you for this package I use in one of my clients website.

But, apparently, not all HTTP request sends a user agent. I've seen in logs this warning:

```
PHP message: PHP Warning: Undefined array key "HTTP_USER_AGENT"
```

That's why I've added a condition in `EasyCSRF.php` file on line 113 to make $_SERVER['HTTP_USER_AGENT'] optional when creating the referral hash.

Of course, I've added the test for this situation.

Best regards.